### PR TITLE
Features(adapters): base interface + DummyAdapter for pipeline smoke …

### DIFF
--- a/ocr-llm-benchmark/adapters/base.py
+++ b/ocr-llm-benchmark/adapters/base.py
@@ -1,0 +1,20 @@
+from abc import ABC, abstractmethod
+from typing import Dict, Any, Optional, Tuple
+
+class BaseAdapter(ABC):
+    name: str = "Base"
+    supports_images: bool = False
+    max_image_res: Optional[Tuple[int, int]] = None  # (W,H) pixels if applicable
+
+    @abstractmethod
+    def infer(self, doc_bytes: bytes, prompt: str, **kwargs) -> Dict[str, Any]:
+        """Return dict with keys:
+        - success: bool
+        - output_json: Optional[dict]
+        - output_text: Optional[str]
+        - timings: {ttft_ms, tpot_ms, gen_time_ms, e2el_ms}
+        - tokens: {input_tokens, output_tokens, estimated: bool}
+        - image_input: {pixels: (w,h)} or None
+        - notes: str
+        """
+        raise NotImplementedError

--- a/ocr-llm-benchmark/adapters/dummy.py
+++ b/ocr-llm-benchmark/adapters/dummy.py
@@ -1,0 +1,34 @@
+import time, json, random
+from typing import Dict, Any
+from adapters.base import BaseAdapter
+
+class DummyAdapter(BaseAdapter):
+    name = "Dummy"
+    supports_images = False
+
+    def infer(self, doc_bytes: bytes, prompt: str, **kwargs) -> Dict[str, Any]:
+        start = time.perf_counter()
+        # Simulate TTFT and generation
+        ttft = random.uniform(0.05, 0.2)
+        time.sleep(ttft)
+        # Simulate token generation
+        out_tokens = random.randint(60, 140)
+        tpot = random.uniform(0.08, 0.2)  # sec per token (slow on purpose)
+        gen_time = out_tokens * tpot
+        time.sleep(min(gen_time, 2.0))  # don't actually wait full time
+
+        total = (time.perf_counter() - start) * 1000.0
+        return {
+            "success": True,
+            "output_json": {"tables": []},
+            "output_text": None,
+            "timings": {
+                "ttft_ms": int(ttft*1000),
+                "tpot_ms": int(tpot*1000),
+                "gen_time_ms": int(gen_time*1000),
+                "e2el_ms": int(total),
+            },
+            "tokens": {"input_tokens": 800, "output_tokens": out_tokens, "estimated": True},
+            "image_input": None,
+            "notes": "Dummy response for wiring & metrics."
+        }


### PR DESCRIPTION
Added BaseAdapter and a DummyAdapter returning synthetic timings & outputs to validate the pipeline without external deps.

- DummyAdapter.infer() returns the documented schema

- No external network calls